### PR TITLE
add price per alcohol unit to beer details

### DIFF
--- a/client/src/components/ItemContainer.js
+++ b/client/src/components/ItemContainer.js
@@ -46,6 +46,16 @@ function ItemContainer(props){
     }
   }
 
+  const units = () => {
+    return (beer.abv*beer_data.container_size);
+  }
+
+  const pricePerUnit = () => {
+      var u = units();
+      return beer.price/u;
+  }
+
+
   if(window.innerWidth >= 700) {
   return(
 
@@ -65,7 +75,13 @@ function ItemContainer(props){
             <Grid.Row><h3 className="brewery_name">{brewery()}</h3></Grid.Row>
             <Grid.Row> <b className="beer_style">{beer_data.sub_category.toUpperCase()}</b></Grid.Row>
             <Grid.Row >
-              <Grid.Column><h4 className="beer_details"><span>Pris: {beer.price}kr</span>  <span>Styrke: {beer.abv}%</span> <span>Størrelse: {beer_data.container_size}cl</span> <span>På lager: {beer.stockLevel}</span></h4></Grid.Column>
+              <Grid.Column><h4 className="beer_details">
+                <span>Pris: {beer.price}kr</span>
+                <span>Styrke: {beer.abv}%</span> 
+                <span>Størrelse: {beer_data.container_size}cl</span>
+                  <br/>
+                <span>Pris per alkoholenhet: {pricePerUnit().toFixed(1)} kr</span>
+                <span>På lager: {beer.stockLevel}</span></h4></Grid.Column>
             </Grid.Row>
           </Grid.Column>
           <Grid.Column width={4}>

--- a/client/src/components/ItemContainer.js
+++ b/client/src/components/ItemContainer.js
@@ -80,7 +80,7 @@ function ItemContainer(props){
                 <span>Styrke: {beer.abv}%</span> 
                 <span>Størrelse: {beer_data.container_size}cl</span>
                   <br/>
-                <span>Pris per alkoholenhet: {pricePerUnit().toFixed(1)} kr</span>
+                <span>Pris per alkoholenhet: {pricePerUnit().toFixed(1)}kr</span>
                 <span>På lager: {beer.stockLevel}</span></h4></Grid.Column>
             </Grid.Row>
           </Grid.Column>


### PR DESCRIPTION
Hi! 

Great website! Here's a small modification that you can consider incorporating. I've added a "Price per alcohol unit" field to the beer details, which can be interesting for customers. Here's a screenshot of the functionality: 

![Screen Shot 2019-09-22 at 21 31 23](https://user-images.githubusercontent.com/1394111/65393507-a88f6400-dd81-11e9-8263-a916c4e91e88.png)

Cheers! 🍻 